### PR TITLE
style: apply Allman brace formatting to remaining files (#8)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,12 @@ scheduler_type_t detect_best_scheduler(void)
     if (free_pages_count > 1000) 
     {
         return SCHEDULER_CFS;        // Most sophisticated
-    } else if (free_pages_count > 100) 
+    } 
+    else if (free_pages_count > 100) 
     {
         return SCHEDULER_PRIORITY;   // Medium complexity
-    } else 
+    } 
+    else 
     {
         return SCHEDULER_ROUND_ROBIN; // Fallback
     }
@@ -117,7 +119,8 @@ static void my_scheduler_add_task(task_t *task) { /* ... */ }
 static task_t *my_scheduler_pick_next_task(void) { /* ... */ }
 static void my_scheduler_task_tick(void) { /* ... */ }
 
-scheduler_ops_t my_scheduler_ops = {
+scheduler_ops_t my_scheduler_ops = 
+{
     .type = SCHEDULER_MY,
     .name = "My Scheduler",
     .init = my_scheduler_init,
@@ -218,7 +221,8 @@ Physical Memory:
 #### 1. New Memory Zone
 ```c
 // Add to memory_zone_t enum
-typedef enum {
+typedef enum 
+{
     ZONE_KERNEL_STATIC,
     ZONE_KERNEL_HEAP,
     ZONE_KERNEL_STACK,
@@ -231,7 +235,8 @@ typedef enum {
 
 #### 2. New Allocation Function
 ```c
-void *my_alloc(size_t size) {
+void *my_alloc(size_t size) 
+{
     // Your allocation logic
     uintptr_t phys = alloc_physical_page();
     int result = arch_map_page(virt_addr, phys, flags);
@@ -296,13 +301,15 @@ isr_my_handler:
 #### 2. Register Handler
 ```c
 // In C
-void my_handler_c(void) {
+void my_handler_c(void) 
+{
     // Handle your interrupt
     LOG_INFO("My interrupt handled");
 }
 
 // Register in IDT
-void register_my_handler(void) {
+void register_my_handler(void) 
+{
     idt_set_gate(MY_IRQ_VECTOR, (uint32_t)isr_my_handler, 0x08, 0x8E);
 }
 ```
@@ -410,7 +417,8 @@ else ifeq ($(ARCH),myarch)
 
 #### 1. Define File System Operations
 ```c
-typedef struct {
+typedef struct 
+{
     const char *name;
     int (*mount)(const char *device, const char *mountpoint);
     int (*open)(const char *path, int flags, vfs_file_t **file);
@@ -422,12 +430,14 @@ typedef struct {
 
 #### 2. Implement File System
 ```c
-static int myfs_open(const char *path, int flags, vfs_file_t **file) {
+static int myfs_open(const char *path, int flags, vfs_file_t **file) 
+{
     // Your file system implementation
     return 0;
 }
 
-vfs_ops_t myfs_ops = {
+vfs_ops_t myfs_ops = 
+{
     .name = "myfs",
     .open = myfs_open,
     // ... other operations
@@ -436,7 +446,8 @@ vfs_ops_t myfs_ops = {
 
 #### 3. Register File System
 ```c
-void register_myfs(void) {
+void register_myfs(void) 
+{
     vfs_register_filesystem(&myfs_ops);
 }
 ```
@@ -468,7 +479,8 @@ make ARCH=x86-64 BUILD_TARGET=desktop
 #### C Code Style
 ```c
 // Function naming: snake_case
-void my_function_name(void) {
+void my_function_name(void) 
+{
     // Variable naming: snake_case
     int my_variable = 0;
     
@@ -476,7 +488,8 @@ void my_function_name(void) {
     const int MAX_SIZE = 1024;
     
     // Error handling
-    if (error_condition) {
+    if (error_condition) 
+    {
         LOG_ERR("Error message");
         return ERROR_CODE;
     }
@@ -507,16 +520,19 @@ void my_function_name(void) {
 
 #### Error Handling
 ```c
-int my_function(void) {
+int my_function(void) 
+{
     // Always check for errors
     void *ptr = kmalloc(size);
-    if (!ptr) {
+    if (!ptr) 
+    {
         LOG_ERR("Failed to allocate memory");
         return -ENOMEM;
     }
     
     // Use error codes consistently
-    if (operation_failed) {
+    if (operation_failed) 
+    {
         kfree(ptr);
         return -EINVAL;
     }

--- a/scripts/analyze_debug_logs.sh
+++ b/scripts/analyze_debug_logs.sh
@@ -14,7 +14,8 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Función para mostrar ayuda
-show_help() {
+show_help() 
+{
     echo -e "${BLUE}IR0 Kernel Debug Log Analyzer${NC}"
     echo ""
     echo "Uso: $0 [OPCIONES] [ARCHIVO_LOG]"
@@ -103,7 +104,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Función para verificar si el archivo existe
-check_file() {
+check_file() 
+{
     if [ ! -f "$LOG_FILE" ]; then
         echo -e "${RED}Error: Archivo de log no encontrado: $LOG_FILE${NC}"
         echo -e "${YELLOW}Tip: Ejecuta el kernel con debugging primero:${NC}"
@@ -114,7 +116,8 @@ check_file() {
 }
 
 # Función para mostrar información del archivo
-show_file_info() {
+show_file_info() 
+{
     echo -e "${BLUE}📊 Analizando archivo: ${YELLOW}$LOG_FILE${NC}"
     echo -e "Tamaño: ${CYAN}$(du -h "$LOG_FILE" | cut -f1)${NC}"
     echo -e "Líneas: ${CYAN}$(wc -l < "$LOG_FILE")${NC}"
@@ -123,7 +126,8 @@ show_file_info() {
 }
 
 # Función para analizar page faults
-analyze_page_faults() {
+analyze_page_faults() 
+{
     if [ "$ANALYZE_PAGE_FAULTS" = true ]; then
         echo -e "${YELLOW}🔍 Analizando Page Faults...${NC}"
         
@@ -151,7 +155,8 @@ analyze_page_faults() {
 }
 
 # Función para analizar interrupciones
-analyze_interrupts() {
+analyze_interrupts() 
+{
     if [ "$ANALYZE_INTERRUPTS" = true ]; then
         echo -e "${YELLOW}🔍 Analizando Interrupciones...${NC}"
         
@@ -177,7 +182,8 @@ analyze_interrupts() {
 }
 
 # Función para analizar ejecución
-analyze_execution() {
+analyze_execution() 
+{
     if [ "$ANALYZE_EXECUTION" = true ]; then
         echo -e "${YELLOW}🔍 Analizando Ejecución...${NC}"
         
@@ -203,7 +209,8 @@ analyze_execution() {
 }
 
 # Función para analizar errores del guest
-analyze_guest_errors() {
+analyze_guest_errors() 
+{
     if [ "$ANALYZE_GUEST_ERRORS" = true ]; then
         echo -e "${YELLOW}🔍 Analizando Errores del Guest...${NC}"
         
@@ -238,7 +245,8 @@ analyze_guest_errors() {
 }
 
 # Función para mostrar resumen general
-show_general_summary() {
+show_general_summary() 
+{
     echo -e "${BLUE}📈 Resumen General${NC}"
     
     local total_lines=$(wc -l < "$LOG_FILE")
@@ -259,7 +267,8 @@ show_general_summary() {
 }
 
 # Función principal
-main() {
+main() 
+{
     check_file
     show_file_info
     

--- a/scripts/build_simple.sh
+++ b/scripts/build_simple.sh
@@ -10,7 +10,8 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Función para mostrar ayuda
-show_help() {
+show_help() 
+{
     echo "Uso: $0 [OPCIONES]"
     echo ""
     echo "OPCIONES:"

--- a/scripts/menu_builder.sh
+++ b/scripts/menu_builder.sh
@@ -12,7 +12,8 @@ BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-print_header() {
+print_header() 
+{
     clear
     echo -e "${CYAN}============================================================${NC}"
     echo -e "${CYAN}           IR0 Kernel - Sistema de Compilación${NC}"
@@ -20,24 +21,29 @@ print_header() {
     echo ""
 }
 
-print_info() {
+print_info() 
+{
     echo -e "${BLUE}[INFO]${NC} $1"
 }
 
-print_success() {
+print_success() 
+{
     echo -e "${GREEN}[SUCCESS]${NC} $1"
 }
 
-print_warning() {
+print_warning() 
+{
     echo -e "${YELLOW}[WARNING]${NC} $1"
 }
 
-print_error() {
+print_error() 
+{
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
 # Función para mostrar el menú principal
-show_main_menu() {
+show_main_menu() 
+{
     print_header
     echo -e "${YELLOW}Menú Principal:${NC}"
     echo ""
@@ -55,7 +61,8 @@ show_main_menu() {
 }
 
 # Función para mostrar menú de arquitecturas
-show_arch_menu() {
+show_arch_menu() 
+{
     echo ""
     echo -e "${YELLOW}Seleccione arquitectura:${NC}"
     echo "1. x86-32 (32-bit)"
@@ -68,7 +75,8 @@ show_arch_menu() {
 }
 
 # Función para mostrar menú de build targets
-show_target_menu() {
+show_target_menu() 
+{
     echo ""
     echo -e "${YELLOW}Seleccione build target:${NC}"
     echo "1. Desktop (Sistema de escritorio)"
@@ -81,7 +89,8 @@ show_target_menu() {
 }
 
 # Función para compilar kernel específico
-compile_specific_kernel() {
+compile_specific_kernel() 
+{
     local arch=""
     local target=""
     
@@ -129,7 +138,8 @@ compile_specific_kernel() {
 }
 
 # Función para compilar todas las arquitecturas
-compile_all_architectures() {
+compile_all_architectures() 
+{
     print_info "Compilando para todas las arquitecturas..."
     
     if ./scripts/build_all.sh -a; then
@@ -144,7 +154,8 @@ compile_all_architectures() {
 }
 
 # Función para compilar todos los build targets
-compile_all_targets() {
+compile_all_targets() 
+{
     print_info "Compilando para todos los build targets..."
     
     if ./scripts/build_all.sh -t; then
@@ -159,7 +170,8 @@ compile_all_targets() {
 }
 
 # Función para compilar todas las combinaciones
-compile_all_combinations() {
+compile_all_combinations() 
+{
     print_info "Compilando todas las combinaciones..."
     
     if ./scripts/build_all.sh -c; then
@@ -174,7 +186,8 @@ compile_all_combinations() {
 }
 
 # Función para crear ISO personalizada
-create_custom_iso() {
+create_custom_iso() 
+{
     local arch=""
     local target=""
     local output_name=""
@@ -242,7 +255,8 @@ create_custom_iso() {
 }
 
 # Función para ejecutar en QEMU
-run_qemu() {
+run_qemu() 
+{
     local arch=""
     local target=""
     
@@ -309,7 +323,8 @@ run_qemu() {
 }
 
 # Función para limpiar archivos
-clean_files() {
+clean_files() 
+{
     print_info "Limpiando archivos de compilación..."
     
     if make clean-all; then
@@ -324,7 +339,8 @@ clean_files() {
 }
 
 # Función para mostrar información del sistema
-show_system_info() {
+show_system_info() 
+{
     print_header
     echo -e "${YELLOW}Información del Sistema:${NC}"
     echo ""
@@ -387,7 +403,8 @@ show_system_info() {
 }
 
 # Función principal del menú
-main_menu() {
+main_menu() 
+{
     while true; do
         show_main_menu
         read -r choice

--- a/setup/README.md
+++ b/setup/README.md
@@ -39,7 +39,8 @@ The Setup Subsystem provides kernel configuration management and build strategy 
 #### Kernel Configuration
 ```c
 // Kernel configuration structure
-struct kernel_config {
+struct kernel_config 
+{
     // Architecture configuration
     arch_config_t arch;
     
@@ -69,7 +70,8 @@ struct kernel_config {
 };
 
 // Architecture configuration
-struct arch_config {
+struct arch_config 
+{
     arch_type_t type;
     bool enable_64bit;
     bool enable_sse;
@@ -79,7 +81,8 @@ struct arch_config {
 };
 
 // Memory configuration
-struct memory_config {
+struct memory_config 
+{
     uint64_t kernel_heap_size;
     uint64_t user_heap_size;
     uint64_t page_size;
@@ -90,7 +93,8 @@ struct memory_config {
 };
 
 // Process configuration
-struct process_config {
+struct process_config 
+{
     uint32_t max_processes;
     uint32_t max_threads_per_process;
     uint32_t default_priority;
@@ -101,7 +105,8 @@ struct process_config {
 };
 
 // File system configuration
-struct filesystem_config {
+struct filesystem_config 
+{
     uint32_t max_open_files;
     uint32_t max_mount_points;
     uint64_t max_file_size;
@@ -112,7 +117,8 @@ struct filesystem_config {
 };
 
 // Driver configuration
-struct driver_config {
+struct driver_config 
+{
     bool enable_pci;
     bool enable_usb;
     bool enable_network;
@@ -123,7 +129,8 @@ struct driver_config {
 };
 
 // Network configuration
-struct network_config {
+struct network_config 
+{
     bool enable_tcp_ip;
     bool enable_udp;
     bool enable_icmp;
@@ -134,7 +141,8 @@ struct network_config {
 };
 
 // Security configuration
-struct security_config {
+struct security_config 
+{
     bool enable_user_mode;
     bool enable_process_isolation;
     bool enable_memory_protection;
@@ -145,7 +153,8 @@ struct security_config {
 };
 
 // Performance configuration
-struct performance_config {
+struct performance_config 
+{
     bool enable_caching;
     bool enable_prefetching;
     bool enable_optimization;
@@ -156,7 +165,8 @@ struct performance_config {
 };
 
 // Debug configuration
-struct debug_config {
+struct debug_config 
+{
     bool enable_logging;
     bool enable_tracing;
     bool enable_profiling;
@@ -172,9 +182,11 @@ struct debug_config {
 #### Desktop Strategy
 ```c
 // Desktop-oriented configuration
-struct desktop_config {
+struct desktop_config 
+{
     // Performance-oriented settings
-    .performance = {
+    .performance = 
+    {
         .enable_caching = true,
         .enable_prefetching = true,
         .enable_optimization = true,
@@ -185,7 +197,8 @@ struct desktop_config {
     },
     
     // User interface settings
-    .ui = {
+    .ui = 
+    {
         .enable_gui = true,
         .enable_window_manager = true,
         .enable_desktop_environment = true,
@@ -194,7 +207,8 @@ struct desktop_config {
     },
     
     // Hardware support
-    .hardware = {
+    .hardware = 
+    {
         .enable_graphics = true,
         .enable_audio = true,
         .enable_usb = true,
@@ -207,9 +221,11 @@ struct desktop_config {
 #### Server Strategy
 ```c
 // Server-oriented configuration
-struct server_config {
+struct server_config 
+{
     // Reliability settings
-    .reliability = {
+    .reliability = 
+    {
         .enable_redundancy = true,
         .enable_failover = true,
         .enable_monitoring = true,
@@ -218,7 +234,8 @@ struct server_config {
     },
     
     // Performance settings
-    .performance = {
+    .performance = 
+    {
         .enable_caching = true,
         .enable_prefetching = false,
         .enable_optimization = true,
@@ -229,7 +246,8 @@ struct server_config {
     },
     
     // Network settings
-    .network = {
+    .network = 
+    {
         .enable_tcp_ip = true,
         .enable_udp = true,
         .enable_icmp = true,
@@ -244,9 +262,11 @@ struct server_config {
 #### IoT Strategy
 ```c
 // IoT-oriented configuration
-struct iot_config {
+struct iot_config 
+{
     // Power management
-    .power = {
+    .power = 
+    {
         .enable_sleep_modes = true,
         .enable_power_saving = true,
         .enable_dynamic_frequency = true,
@@ -255,7 +275,8 @@ struct iot_config {
     },
     
     // Resource constraints
-    .resources = {
+    .resources = 
+    {
         .max_memory = 64 * 1024 * 1024,  // 64MB
         .max_storage = 512 * 1024 * 1024,  // 512MB
         .max_processes = 32,
@@ -264,7 +285,8 @@ struct iot_config {
     },
     
     // Communication
-    .communication = {
+    .communication = 
+    {
         .enable_wifi = true,
         .enable_bluetooth = true,
         .enable_zigbee = true,
@@ -278,9 +300,11 @@ struct iot_config {
 #### Embedded Strategy
 ```c
 // Embedded-oriented configuration
-struct embedded_config {
+struct embedded_config 
+{
     // Minimal configuration
-    .minimal = {
+    .minimal = 
+    {
         .enable_gui = false,
         .enable_network = false,
         .enable_storage = false,
@@ -290,7 +314,8 @@ struct embedded_config {
     },
     
     // Real-time settings
-    .realtime = {
+    .realtime = 
+    {
         .enable_preemption = true,
         .enable_priority_inheritance = true,
         .enable_deadline_scheduling = true,
@@ -299,7 +324,8 @@ struct embedded_config {
     },
     
     // Hardware abstraction
-    .hardware = {
+    .hardware = 
+    {
         .enable_gpio = true,
         .enable_spi = true,
         .enable_i2c = true,
@@ -315,49 +341,59 @@ struct embedded_config {
 #### Configuration Validation
 ```c
 // Validate kernel configuration
-bool validate_kernel_config(const kernel_config_t* config) {
+bool validate_kernel_config(const kernel_config_t* config) 
+{
     // Validate architecture configuration
-    if (!validate_arch_config(&config->arch)) {
+    if (!validate_arch_config(&config->arch)) 
+    {
         return false;
     }
     
     // Validate memory configuration
-    if (!validate_memory_config(&config->memory)) {
+    if (!validate_memory_config(&config->memory)) 
+    {
         return false;
     }
     
     // Validate process configuration
-    if (!validate_process_config(&config->process)) {
+    if (!validate_process_config(&config->process)) 
+    {
     return false;
 }
     
     // Validate file system configuration
-    if (!validate_filesystem_config(&config->filesystem)) {
+    if (!validate_filesystem_config(&config->filesystem)) 
+    {
         return false;
     }
     
     // Validate driver configuration
-    if (!validate_driver_config(&config->driver)) {
+    if (!validate_driver_config(&config->driver)) 
+    {
         return false;
     }
     
     // Validate network configuration
-    if (!validate_network_config(&config->network)) {
+    if (!validate_network_config(&config->network)) 
+    {
         return false;
     }
     
     // Validate security configuration
-    if (!validate_security_config(&config->security)) {
+    if (!validate_security_config(&config->security)) 
+    {
         return false;
     }
     
     // Validate performance configuration
-    if (!validate_performance_config(&config->performance)) {
+    if (!validate_performance_config(&config->performance)) 
+    {
         return false;
     }
     
     // Validate debug configuration
-    if (!validate_debug_config(&config->debug)) {
+    if (!validate_debug_config(&config->debug)) 
+    {
         return false;
     }
     
@@ -365,19 +401,23 @@ bool validate_kernel_config(const kernel_config_t* config) {
 }
 
 // Validate architecture configuration
-bool validate_arch_config(const arch_config_t* config) {
+bool validate_arch_config(const arch_config_t* config) 
+{
     // Check architecture type
-    if (config->type < ARCH_X86_32 || config->type > ARCH_ARM64) {
+    if (config->type < ARCH_X86_32 || config->type > ARCH_ARM64) 
+    {
         return false;
     }
     
     // Check CPU count
-    if (config->max_cpus == 0 || config->max_cpus > MAX_CPUS) {
+    if (config->max_cpus == 0 || config->max_cpus > MAX_CPUS) 
+    {
         return false;
     }
     
     // Check feature compatibility
-    if (config->enable_64bit && config->type == ARCH_X86_32) {
+    if (config->enable_64bit && config->type == ARCH_X86_32) 
+    {
         return false;
     }
     
@@ -385,19 +425,23 @@ bool validate_arch_config(const arch_config_t* config) {
 }
 
 // Validate memory configuration
-bool validate_memory_config(const memory_config_t* config) {
+bool validate_memory_config(const memory_config_t* config) 
+{
     // Check heap sizes
-    if (config->kernel_heap_size == 0 || config->user_heap_size == 0) {
+    if (config->kernel_heap_size == 0 || config->user_heap_size == 0) 
+    {
         return false;
     }
     
     // Check page size
-    if (config->page_size != 4096 && config->page_size != 8192) {
+    if (config->page_size != 4096 && config->page_size != 8192) 
+    {
         return false;
     }
     
     // Check physical page count
-    if (config->max_physical_pages == 0) {
+    if (config->max_physical_pages == 0) 
+    {
         return false;
     }
     
@@ -408,15 +452,18 @@ bool validate_memory_config(const memory_config_t* config) {
 #### Dynamic Configuration Updates
 ```c
 // Update kernel configuration dynamically
-bool update_kernel_config(kernel_config_t* config, const char* key, const char* value) {
+bool update_kernel_config(kernel_config_t* config, const char* key, const char* value) 
+{
     // Parse configuration key
     config_key_t parsed_key = parse_config_key(key);
-    if (parsed_key == CONFIG_KEY_INVALID) {
+    if (parsed_key == CONFIG_KEY_INVALID) 
+    {
         return false;
     }
     
     // Update configuration value
-    switch (parsed_key) {
+    switch (parsed_key) 
+    {
         case CONFIG_KEY_KERNEL_HEAP_SIZE:
             return update_kernel_heap_size(config, value);
             
@@ -438,14 +485,17 @@ bool update_kernel_config(kernel_config_t* config, const char* key, const char* 
 }
 
 // Update kernel heap size
-bool update_kernel_heap_size(kernel_config_t* config, const char* value) {
+bool update_kernel_heap_size(kernel_config_t* config, const char* value) 
+{
     uint64_t new_size = parse_size_string(value);
-    if (new_size == 0) {
+    if (new_size == 0) 
+    {
         return false;
     }
     
     // Validate new size
-    if (new_size < MIN_KERNEL_HEAP_SIZE || new_size > MAX_KERNEL_HEAP_SIZE) {
+    if (new_size < MIN_KERNEL_HEAP_SIZE || new_size > MAX_KERNEL_HEAP_SIZE) 
+    {
         return false;
     }
     
@@ -457,14 +507,17 @@ bool update_kernel_heap_size(kernel_config_t* config, const char* value) {
 }
 
 // Update user heap size
-bool update_user_heap_size(kernel_config_t* config, const char* value) {
+bool update_user_heap_size(kernel_config_t* config, const char* value) 
+{
     uint64_t new_size = parse_size_string(value);
-    if (new_size == 0) {
+    if (new_size == 0) 
+    {
         return false;
     }
     
     // Validate new size
-    if (new_size < MIN_USER_HEAP_SIZE || new_size > MAX_USER_HEAP_SIZE) {
+    if (new_size < MIN_USER_HEAP_SIZE || new_size > MAX_USER_HEAP_SIZE) 
+    {
         return false;
     }
     
@@ -479,10 +532,12 @@ bool update_user_heap_size(kernel_config_t* config, const char* value) {
 #### Configuration Persistence
 ```c
 // Save configuration to persistent storage
-bool save_kernel_config(const kernel_config_t* config) {
+bool save_kernel_config(const kernel_config_t* config) 
+{
     // Serialize configuration
     uint8_t* buffer = serialize_kernel_config(config);
-    if (buffer == NULL) {
+    if (buffer == NULL) 
+    {
         return false;
     }
     
@@ -499,10 +554,12 @@ bool save_kernel_config(const kernel_config_t* config) {
 }
 
 // Load configuration from persistent storage
-bool load_kernel_config(kernel_config_t* config) {
+bool load_kernel_config(kernel_config_t* config) 
+{
     // Read from storage
     uint8_t* buffer = read_config_from_storage();
-    if (buffer == NULL) {
+    if (buffer == NULL) 
+    {
         return false;
     }
     
@@ -510,7 +567,8 @@ bool load_kernel_config(kernel_config_t* config) {
     uint32_t stored_checksum = get_stored_checksum();
     uint32_t calculated_checksum = calculate_checksum(buffer, CONFIG_SIZE);
     
-    if (stored_checksum != calculated_checksum) {
+    if (stored_checksum != calculated_checksum) 
+    {
         kfree(buffer);
         return false;
     }
@@ -525,9 +583,11 @@ bool load_kernel_config(kernel_config_t* config) {
 }
 
 // Serialize kernel configuration
-uint8_t* serialize_kernel_config(const kernel_config_t* config) {
+uint8_t* serialize_kernel_config(const kernel_config_t* config) 
+{
     uint8_t* buffer = kmalloc(CONFIG_SIZE);
-    if (buffer == NULL) {
+    if (buffer == NULL) 
+    {
         return NULL;
     }
     
@@ -578,7 +638,8 @@ uint8_t* serialize_kernel_config(const kernel_config_t* config) {
 #### Strategy Selection
 ```c
 // Build strategy types
-typedef enum {
+typedef enum 
+{
     BUILD_STRATEGY_DESKTOP,
     BUILD_STRATEGY_SERVER,
     BUILD_STRATEGY_IOT,
@@ -587,8 +648,10 @@ typedef enum {
 } build_strategy_t;
 
 // Select build strategy
-bool select_build_strategy(build_strategy_t strategy, kernel_config_t* config) {
-    switch (strategy) {
+bool select_build_strategy(build_strategy_t strategy, kernel_config_t* config) 
+{
+    switch (strategy) 
+    {
         case BUILD_STRATEGY_DESKTOP:
             return apply_desktop_strategy(config);
             
@@ -610,7 +673,8 @@ bool select_build_strategy(build_strategy_t strategy, kernel_config_t* config) {
 }
 
 // Apply desktop strategy
-bool apply_desktop_strategy(kernel_config_t* config) {
+bool apply_desktop_strategy(kernel_config_t* config) 
+{
     // Set desktop-specific configuration
     config->performance.enable_caching = true;
     config->performance.enable_prefetching = true;
@@ -638,7 +702,8 @@ bool apply_desktop_strategy(kernel_config_t* config) {
 }
 
 // Apply server strategy
-bool apply_server_strategy(kernel_config_t* config) {
+bool apply_server_strategy(kernel_config_t* config) 
+{
     // Set server-specific configuration
     config->reliability.enable_redundancy = true;
     config->reliability.enable_failover = true;
@@ -739,7 +804,8 @@ El Subsistema de Setup proporciona gestión de configuración del kernel y siste
 #### Configuración del Kernel
 ```c
 // Estructura de configuración del kernel
-struct kernel_config {
+struct kernel_config 
+{
     // Configuración de arquitectura
     arch_config_t arch;
     
@@ -769,7 +835,8 @@ struct kernel_config {
 };
 
 // Configuración de arquitectura
-struct arch_config {
+struct arch_config 
+{
     arch_type_t type;
     bool enable_64bit;
     bool enable_sse;
@@ -779,7 +846,8 @@ struct arch_config {
 };
 
 // Configuración de memoria
-struct memory_config {
+struct memory_config 
+{
     uint64_t kernel_heap_size;
     uint64_t user_heap_size;
     uint64_t page_size;
@@ -790,7 +858,8 @@ struct memory_config {
 };
 
 // Configuración de procesos
-struct process_config {
+struct process_config 
+{
     uint32_t max_processes;
     uint32_t max_threads_per_process;
     uint32_t default_priority;
@@ -801,7 +870,8 @@ struct process_config {
 };
 
 // Configuración de filesystem
-struct filesystem_config {
+struct filesystem_config 
+{
     uint32_t max_open_files;
     uint32_t max_mount_points;
     uint64_t max_file_size;
@@ -812,7 +882,8 @@ struct filesystem_config {
 };
 
 // Configuración de drivers
-struct driver_config {
+struct driver_config 
+{
     bool enable_pci;
     bool enable_usb;
     bool enable_network;
@@ -823,7 +894,8 @@ struct driver_config {
 };
 
 // Configuración de red
-struct network_config {
+struct network_config 
+{
     bool enable_tcp_ip;
     bool enable_udp;
     bool enable_icmp;
@@ -834,7 +906,8 @@ struct network_config {
 };
 
 // Configuración de seguridad
-struct security_config {
+struct security_config 
+{
     bool enable_user_mode;
     bool enable_process_isolation;
     bool enable_memory_protection;
@@ -845,7 +918,8 @@ struct security_config {
 };
 
 // Configuración de rendimiento
-struct performance_config {
+struct performance_config 
+{
     bool enable_caching;
     bool enable_prefetching;
     bool enable_optimization;
@@ -856,7 +930,8 @@ struct performance_config {
 };
 
 // Configuración de debug
-struct debug_config {
+struct debug_config 
+{
     bool enable_logging;
     bool enable_tracing;
     bool enable_profiling;
@@ -872,9 +947,11 @@ struct debug_config {
 #### Estrategia Desktop
 ```c
 // Configuración orientada a desktop
-struct desktop_config {
+struct desktop_config 
+{
     // Configuración orientada a rendimiento
-    .performance = {
+    .performance = 
+    {
         .enable_caching = true,
         .enable_prefetching = true,
         .enable_optimization = true,
@@ -885,7 +962,8 @@ struct desktop_config {
     },
     
     // Configuración de interfaz de usuario
-    .ui = {
+    .ui = 
+    {
         .enable_gui = true,
         .enable_window_manager = true,
         .enable_desktop_environment = true,
@@ -894,7 +972,8 @@ struct desktop_config {
     },
     
     // Soporte de hardware
-    .hardware = {
+    .hardware = 
+    {
         .enable_graphics = true,
         .enable_audio = true,
         .enable_usb = true,
@@ -907,9 +986,11 @@ struct desktop_config {
 #### Estrategia Server
 ```c
 // Configuración orientada a servidor
-struct server_config {
+struct server_config 
+{
     // Configuración de confiabilidad
-    .reliability = {
+    .reliability = 
+    {
         .enable_redundancy = true,
         .enable_failover = true,
         .enable_monitoring = true,
@@ -918,7 +999,8 @@ struct server_config {
     },
     
     // Configuración de rendimiento
-    .performance = {
+    .performance = 
+    {
         .enable_caching = true,
         .enable_prefetching = false,
         .enable_optimization = true,
@@ -929,7 +1011,8 @@ struct server_config {
     },
     
     // Configuración de red
-    .network = {
+    .network = 
+    {
         .enable_tcp_ip = true,
         .enable_udp = true,
         .enable_icmp = true,
@@ -944,9 +1027,11 @@ struct server_config {
 #### Estrategia IoT
 ```c
 // Configuración orientada a IoT
-struct iot_config {
+struct iot_config 
+{
     // Gestión de energía
-    .power = {
+    .power = 
+    {
         .enable_sleep_modes = true,
         .enable_power_saving = true,
         .enable_dynamic_frequency = true,
@@ -955,7 +1040,8 @@ struct iot_config {
     },
     
     // Restricciones de recursos
-    .resources = {
+    .resources = 
+    {
         .max_memory = 64 * 1024 * 1024,  // 64MB
         .max_storage = 512 * 1024 * 1024,  // 512MB
         .max_processes = 32,
@@ -964,7 +1050,8 @@ struct iot_config {
     },
     
     // Comunicación
-    .communication = {
+    .communication = 
+    {
         .enable_wifi = true,
         .enable_bluetooth = true,
         .enable_zigbee = true,
@@ -978,9 +1065,11 @@ struct iot_config {
 #### Estrategia Embedded
 ```c
 // Configuración orientada a embedded
-struct embedded_config {
+struct embedded_config 
+{
     // Configuración mínima
-    .minimal = {
+    .minimal = 
+    {
         .enable_gui = false,
         .enable_network = false,
         .enable_storage = false,
@@ -990,7 +1079,8 @@ struct embedded_config {
     },
     
     // Configuración de tiempo real
-    .realtime = {
+    .realtime = 
+    {
         .enable_preemption = true,
         .enable_priority_inheritance = true,
         .enable_deadline_scheduling = true,
@@ -999,7 +1089,8 @@ struct embedded_config {
     },
     
     // Abstracción de hardware
-    .hardware = {
+    .hardware = 
+    {
         .enable_gpio = true,
         .enable_spi = true,
         .enable_i2c = true,
@@ -1015,49 +1106,59 @@ struct embedded_config {
 #### Validación de Configuración
 ```c
 // Validar configuración del kernel
-bool validate_kernel_config(const kernel_config_t* config) {
+bool validate_kernel_config(const kernel_config_t* config) 
+{
     // Validar configuración de arquitectura
-    if (!validate_arch_config(&config->arch)) {
+    if (!validate_arch_config(&config->arch)) 
+    {
         return false;
     }
     
     // Validar configuración de memoria
-    if (!validate_memory_config(&config->memory)) {
+    if (!validate_memory_config(&config->memory)) 
+    {
         return false;
     }
     
     // Validar configuración de procesos
-    if (!validate_process_config(&config->process)) {
+    if (!validate_process_config(&config->process)) 
+    {
     return false;
-}
+    }
     
     // Validar configuración de filesystem
-    if (!validate_filesystem_config(&config->filesystem)) {
+    if (!validate_filesystem_config(&config->filesystem)) 
+    {
         return false;
     }
     
     // Validar configuración de drivers
-    if (!validate_driver_config(&config->driver)) {
+    if (!validate_driver_config(&config->driver)) 
+    {
         return false;
     }
     
     // Validar configuración de red
-    if (!validate_network_config(&config->network)) {
+    if (!validate_network_config(&config->network)) 
+    {
         return false;
     }
     
     // Validar configuración de seguridad
-    if (!validate_security_config(&config->security)) {
+    if (!validate_security_config(&config->security)) 
+    {
         return false;
     }
     
     // Validar configuración de rendimiento
-    if (!validate_performance_config(&config->performance)) {
+    if (!validate_performance_config(&config->performance)) 
+    {
         return false;
     }
     
     // Validar configuración de debug
-    if (!validate_debug_config(&config->debug)) {
+    if (!validate_debug_config(&config->debug)) 
+    {
         return false;
     }
     
@@ -1065,19 +1166,23 @@ bool validate_kernel_config(const kernel_config_t* config) {
 }
 
 // Validar configuración de arquitectura
-bool validate_arch_config(const arch_config_t* config) {
+bool validate_arch_config(const arch_config_t* config) 
+{
     // Verificar tipo de arquitectura
-    if (config->type < ARCH_X86_32 || config->type > ARCH_ARM64) {
+    if (config->type < ARCH_X86_32 || config->type > ARCH_ARM64) 
+    {
         return false;
     }
     
     // Verificar número de CPUs
-    if (config->max_cpus == 0 || config->max_cpus > MAX_CPUS) {
+    if (config->max_cpus == 0 || config->max_cpus > MAX_CPUS) 
+    {
         return false;
     }
     
     // Verificar compatibilidad de características
-    if (config->enable_64bit && config->type == ARCH_X86_32) {
+    if (config->enable_64bit && config->type == ARCH_X86_32) 
+    {
         return false;
     }
     
@@ -1085,19 +1190,23 @@ bool validate_arch_config(const arch_config_t* config) {
 }
 
 // Validar configuración de memoria
-bool validate_memory_config(const memory_config_t* config) {
+bool validate_memory_config(const memory_config_t* config) 
+{
     // Verificar tamaños de heap
-    if (config->kernel_heap_size == 0 || config->user_heap_size == 0) {
+    if (config->kernel_heap_size == 0 || config->user_heap_size == 0) 
+    {
         return false;
     }
     
     // Verificar tamaño de página
-    if (config->page_size != 4096 && config->page_size != 8192) {
+    if (config->page_size != 4096 && config->page_size != 8192) 
+    {
         return false;
     }
     
     // Verificar número de páginas físicas
-    if (config->max_physical_pages == 0) {
+    if (config->max_physical_pages == 0) 
+    {
         return false;
     }
     
@@ -1108,15 +1217,18 @@ bool validate_memory_config(const memory_config_t* config) {
 #### Actualizaciones Dinámicas de Configuración
 ```c
 // Actualizar configuración del kernel dinámicamente
-bool update_kernel_config(kernel_config_t* config, const char* key, const char* value) {
+bool update_kernel_config(kernel_config_t* config, const char* key, const char* value) 
+{
     // Parsear clave de configuración
     config_key_t parsed_key = parse_config_key(key);
-    if (parsed_key == CONFIG_KEY_INVALID) {
+    if (parsed_key == CONFIG_KEY_INVALID) 
+    {
         return false;
     }
     
     // Actualizar valor de configuración
-    switch (parsed_key) {
+    switch (parsed_key) 
+    {
         case CONFIG_KEY_KERNEL_HEAP_SIZE:
             return update_kernel_heap_size(config, value);
             
@@ -1138,14 +1250,17 @@ bool update_kernel_config(kernel_config_t* config, const char* key, const char* 
 }
 
 // Actualizar tamaño de heap del kernel
-bool update_kernel_heap_size(kernel_config_t* config, const char* value) {
+bool update_kernel_heap_size(kernel_config_t* config, const char* value) 
+{
     uint64_t new_size = parse_size_string(value);
-    if (new_size == 0) {
+    if (new_size == 0) 
+    {
         return false;
     }
     
     // Validar nuevo tamaño
-    if (new_size < MIN_KERNEL_HEAP_SIZE || new_size > MAX_KERNEL_HEAP_SIZE) {
+    if (new_size < MIN_KERNEL_HEAP_SIZE || new_size > MAX_KERNEL_HEAP_SIZE) 
+    {
         return false;
     }
     
@@ -1157,14 +1272,17 @@ bool update_kernel_heap_size(kernel_config_t* config, const char* value) {
 }
 
 // Actualizar tamaño de heap de usuario
-bool update_user_heap_size(kernel_config_t* config, const char* value) {
+bool update_user_heap_size(kernel_config_t* config, const char* value) 
+{
     uint64_t new_size = parse_size_string(value);
-    if (new_size == 0) {
+    if (new_size == 0) 
+    {
         return false;
     }
     
     // Validar nuevo tamaño
-    if (new_size < MIN_USER_HEAP_SIZE || new_size > MAX_USER_HEAP_SIZE) {
+    if (new_size < MIN_USER_HEAP_SIZE || new_size > MAX_USER_HEAP_SIZE) 
+    {
         return false;
     }
     
@@ -1179,10 +1297,12 @@ bool update_user_heap_size(kernel_config_t* config, const char* value) {
 #### Persistencia de Configuración
 ```c
 // Guardar configuración en almacenamiento persistente
-bool save_kernel_config(const kernel_config_t* config) {
+bool save_kernel_config(const kernel_config_t* config) 
+{
     // Serializar configuración
     uint8_t* buffer = serialize_kernel_config(config);
-    if (buffer == NULL) {
+    if (buffer == NULL) 
+    {
         return false;
     }
     
@@ -1199,10 +1319,12 @@ bool save_kernel_config(const kernel_config_t* config) {
 }
 
 // Cargar configuración desde almacenamiento persistente
-bool load_kernel_config(kernel_config_t* config) {
+bool load_kernel_config(kernel_config_t* config) 
+{
     // Leer desde almacenamiento
     uint8_t* buffer = read_config_from_storage();
-    if (buffer == NULL) {
+    if (buffer == NULL) 
+    {
         return false;
     }
     
@@ -1210,7 +1332,8 @@ bool load_kernel_config(kernel_config_t* config) {
     uint32_t stored_checksum = get_stored_checksum();
     uint32_t calculated_checksum = calculate_checksum(buffer, CONFIG_SIZE);
     
-    if (stored_checksum != calculated_checksum) {
+    if (stored_checksum != calculated_checksum) 
+    {
         kfree(buffer);
         return false;
     }
@@ -1225,9 +1348,11 @@ bool load_kernel_config(kernel_config_t* config) {
 }
 
 // Serializar configuración del kernel
-uint8_t* serialize_kernel_config(const kernel_config_t* config) {
+uint8_t* serialize_kernel_config(const kernel_config_t* config) 
+{
     uint8_t* buffer = kmalloc(CONFIG_SIZE);
-    if (buffer == NULL) {
+    if (buffer == NULL) 
+    {
         return NULL;
     }
     
@@ -1278,7 +1403,8 @@ uint8_t* serialize_kernel_config(const kernel_config_t* config) {
 #### Selección de Estrategia
 ```c
 // Tipos de estrategia de build
-typedef enum {
+typedef enum 
+{
     BUILD_STRATEGY_DESKTOP,
     BUILD_STRATEGY_SERVER,
     BUILD_STRATEGY_IOT,
@@ -1287,8 +1413,10 @@ typedef enum {
 } build_strategy_t;
 
 // Seleccionar estrategia de build
-bool select_build_strategy(build_strategy_t strategy, kernel_config_t* config) {
-    switch (strategy) {
+bool select_build_strategy(build_strategy_t strategy, kernel_config_t* config) 
+{
+    switch (strategy) 
+    {
         case BUILD_STRATEGY_DESKTOP:
             return apply_desktop_strategy(config);
             
@@ -1310,7 +1438,8 @@ bool select_build_strategy(build_strategy_t strategy, kernel_config_t* config) {
 }
 
 // Aplicar estrategia desktop
-bool apply_desktop_strategy(kernel_config_t* config) {
+bool apply_desktop_strategy(kernel_config_t* config) 
+{
     // Establecer configuración específica de desktop
     config->performance.enable_caching = true;
     config->performance.enable_prefetching = true;
@@ -1338,7 +1467,8 @@ bool apply_desktop_strategy(kernel_config_t* config) {
 }
 
 // Aplicar estrategia servidor
-bool apply_server_strategy(kernel_config_t* config) {
+bool apply_server_strategy(kernel_config_t* config) 
+{
     // Establecer configuración específica de servidor
     config->reliability.enable_redundancy = true;
     config->reliability.enable_failover = true;

--- a/setup/docs/ARM_PORTABILITY_GUIDE.md
+++ b/setup/docs/ARM_PORTABILITY_GUIDE.md
@@ -184,7 +184,8 @@ make ARCH=arm-32
 ```c
 #include <arch_portable.h>
 
-void init_system(void) {
+void init_system(void) 
+{
     // Initialize architecture-specific components
     arch_early_init();
     arch_memory_init();
@@ -196,7 +197,8 @@ void init_system(void) {
     arch_enable_interrupts();
 }
 
-void handle_io(void) {
+void handle_io(void) 
+{
     // Portable I/O operations
     uint8_t value = arch_io_read8(0x3F8);  // UART on ARM, port on x86
     arch_io_write8(0x3F8, value);

--- a/setup/docs/CONFIGURATION_SYSTEM_README.md
+++ b/setup/docs/CONFIGURATION_SYSTEM_README.md
@@ -24,10 +24,12 @@
 #define IR0_DEVELOPMENT_MODE
 #include <ir0/kernel_includes.h>
 
-void main(void) {
+void main(void) 
+{
     // Your tests here / Tus tests aquí
     void *ptr = kmalloc(16);
-    if (ptr) {
+    if (ptr) 
+    {
         print_colored("✓ Bump allocator working!\n", VGA_COLOR_GREEN, VGA_COLOR_BLACK);
     }
 }
@@ -39,7 +41,8 @@ void main(void) {
 #define IR0_DESKTOP
 #include <ir0/kernel_includes.h>
 
-void main(void) {
+void main(void) 
+{
     // Full system with scheduler, VFS, GUI / Sistema completo con scheduler, VFS, GUI
 }
 ```

--- a/setup/docs/INCLUDE_SYSTEM_GUIDE.md
+++ b/setup/docs/INCLUDE_SYSTEM_GUIDE.md
@@ -97,7 +97,8 @@ examples/
 #define IR0_DEVELOPMENT_MODE
 #include <ir0/kernel_includes.h>
 
-void main(void) {
+void main(void) 
+{
     // Banners and basic init / Banners e inicialización básica
     // ... your tests / ... tus tests
 }
@@ -109,7 +110,8 @@ void main(void) {
 #define IR0_DESKTOP
 #include <ir0/kernel_includes.h>
 
-void main(void) {
+void main(void) 
+{
     // Full system initialization / Inicialización completa del sistema
     // All subsystems available / Todos los subsistemas disponibles
 }

--- a/setup/kernel_config.c
+++ b/setup/kernel_config.c
@@ -7,88 +7,141 @@
 // CONFIGURATION FUNCTIONS IMPLEMENTATION
 // ===============================================================================
 
-const char* ir0_get_target_name(void) {
+const char* ir0_get_target_name(void) 
+{
     return IR0_TARGET_NAME;
 }
 
-const char* ir0_get_target_description(void) {
+const char* ir0_get_target_description(void) 
+{
     return IR0_TARGET_DESCRIPTION;
 }
 
-const char* ir0_get_version_string(void) {
+const char* ir0_get_version_string(void) 
+{
     return IR0_VERSION_STRING;
 }
 
-const char* ir0_get_build_date(void) {
+const char* ir0_get_build_date(void) 
+{
     return IR0_BUILD_DATE;
 }
 
-const char* ir0_get_build_time(void) {
+const char* ir0_get_build_time(void) 
+{
     return IR0_BUILD_TIME;
 }
 
-bool ir0_is_feature_enabled(const char* feature) {
+bool ir0_is_feature_enabled(const char* feature) 
+{
     if (!feature) return false;
     
-    if (strcmp(feature, "GUI") == 0) {
+    if (strcmp(feature, "GUI") == 0) 
+    {
         return IR0_ENABLE_GUI;
-    } else if (strcmp(feature, "AUDIO") == 0) {
+    } 
+    else if (strcmp(feature, "AUDIO") == 0) 
+    {
         return IR0_ENABLE_AUDIO;
-    } else if (strcmp(feature, "USB") == 0) {
+    } 
+    else if (strcmp(feature, "USB") == 0) 
+    {
         return IR0_ENABLE_USB;
-    } else if (strcmp(feature, "NETWORKING") == 0) {
+    } 
+    else if (strcmp(feature, "NETWORKING") == 0) 
+    {
         return IR0_ENABLE_NETWORKING;
-    } else if (strcmp(feature, "FILESYSTEM") == 0) {
+    } 
+    else if (strcmp(feature, "FILESYSTEM") == 0) 
+    {
         return IR0_ENABLE_FILESYSTEM;
-    } else if (strcmp(feature, "MULTIMEDIA") == 0) {
+    } 
+    else if (strcmp(feature, "MULTIMEDIA") == 0) 
+    {
         return IR0_ENABLE_MULTIMEDIA;
-    } else if (strcmp(feature, "PRINTING") == 0) {
+    } 
+    else if (strcmp(feature, "PRINTING") == 0) 
+    {
         return IR0_ENABLE_PRINTING;
-    } else if (strcmp(feature, "VFS") == 0) {
+    } 
+    else if (strcmp(feature, "VFS") == 0) 
+    {
         return IR0_ENABLE_VFS;
-    } else if (strcmp(feature, "TCPIP") == 0) {
+    } 
+    else if (strcmp(feature, "TCPIP") == 0) 
+    {
         return IR0_ENABLE_TCPIP;
-    } else if (strcmp(feature, "SOCKETS") == 0) {
+    } 
+    else if (strcmp(feature, "SOCKETS") == 0) 
+    {
         return IR0_ENABLE_SOCKETS;
-    } else if (strcmp(feature, "ETHERNET") == 0) {
+    } 
+    else if (strcmp(feature, "ETHERNET") == 0) 
+    {
         return IR0_ENABLE_ETHERNET;
-    } else if (strcmp(feature, "USB_DRIVER") == 0) {
+    } 
+    else if (strcmp(feature, "USB_DRIVER") == 0) 
+    {
         return IR0_ENABLE_USB_DRIVER;
-    } else if (strcmp(feature, "VGA_DRIVER") == 0) {
+    } 
+    else if (strcmp(feature, "VGA_DRIVER") == 0) 
+    {
         return IR0_ENABLE_VGA_DRIVER;
-    } else if (strcmp(feature, "FRAMEBUFFER") == 0) {
+    } 
+    else if (strcmp(feature, "FRAMEBUFFER") == 0) 
+    {
         return IR0_ENABLE_FRAMEBUFFER;
-    } else if (strcmp(feature, "WINDOW_MANAGER") == 0) {
+    } 
+    else if (strcmp(feature, "WINDOW_MANAGER") == 0) 
+    {
         return IR0_ENABLE_WINDOW_MANAGER;
-    } else if (strcmp(feature, "SOUND_DRIVER") == 0) {
+    } 
+    else if (strcmp(feature, "SOUND_DRIVER") == 0) 
+    {
         return IR0_ENABLE_SOUND_DRIVER;
-    } else if (strcmp(feature, "AUDIO_MIXER") == 0) {
+    } 
+    else if (strcmp(feature, "AUDIO_MIXER") == 0) 
+    {
         return IR0_ENABLE_AUDIO_MIXER;
-    } else if (strcmp(feature, "USER_MODE") == 0) {
+    } 
+    else if (strcmp(feature, "USER_MODE") == 0) 
+    {
         return IR0_ENABLE_USER_MODE;
-    } else if (strcmp(feature, "MEMORY_PROTECTION") == 0) {
+    } 
+    else if (strcmp(feature, "MEMORY_PROTECTION") == 0) 
+    {
         return IR0_ENABLE_MEMORY_PROTECTION;
-    } else if (strcmp(feature, "PROCESS_ISOLATION") == 0) {
+    } 
+    else if (strcmp(feature, "PROCESS_ISOLATION") == 0) 
+    {
         return IR0_ENABLE_PROCESS_ISOLATION;
-    } else if (strcmp(feature, "POWER_MANAGEMENT") == 0) {
+    } 
+    else if (strcmp(feature, "POWER_MANAGEMENT") == 0) 
+    {
         #ifdef IR0_ENABLE_POWER_MANAGEMENT
             return IR0_ENABLE_POWER_MANAGEMENT;
         #else
             return false;
         #endif
-    } else if (strcmp(feature, "SLEEP_MODES") == 0) {
+    } 
+    else if (strcmp(feature, "SLEEP_MODES") == 0) 
+    {
         #ifdef IR0_ENABLE_SLEEP_MODES
             return IR0_ENABLE_SLEEP_MODES;
         #else
             return false;
         #endif
-    } else if (strcmp(feature, "LOW_POWER_TIMERS") == 0) {
+    } 
+    else if (strcmp(feature, "LOW_POWER_TIMERS") == 0) 
+    {
         #ifdef IR0_ENABLE_LOW_POWER_TIMERS
             return IR0_ENABLE_LOW_POWER_TIMERS;
         #else
             return false;
         #endif
-    } else if (strcmp(feature, "NETWORK_SECURITY") == 0) {
+    } 
+    else if (strcmp(feature, "NETWORK_SECURITY") == 0) 
+    {
         #ifdef IR0_ENABLE_NETWORK_SECURITY
             return IR0_ENABLE_NETWORK_SECURITY;
         #else
@@ -99,7 +152,8 @@ bool ir0_is_feature_enabled(const char* feature) {
     return false;
 }
 
-void ir0_print_build_config(void) {
+void ir0_print_build_config(void) 
+{
     print_colored("=== IR0 KERNEL BUILD CONFIGURATION ===\n", 0x0A, 0x00);
     
     print_colored("Target: ", 0x0B, 0x00);
@@ -141,7 +195,8 @@ void ir0_print_build_config(void) {
     
     print_colored("Enabled Features:\n", 0x0B, 0x00);
     
-    const char* features[] = {
+    const char* features[] = 
+    {
         "GUI", "AUDIO", "USB", "NETWORKING", "FILESYSTEM", 
         "MULTIMEDIA", "PRINTING", "VFS", "TCPIP", "SOCKETS",
         "ETHERNET", "USB_DRIVER", "VGA_DRIVER", "FRAMEBUFFER",
@@ -154,7 +209,8 @@ void ir0_print_build_config(void) {
     int enabled_count = 0;
     for (size_t i = 0; i < sizeof(features) / sizeof(features[0]); i++) 
     {
-        if (ir0_is_feature_enabled(features[i])) {
+        if (ir0_is_feature_enabled(features[i])) 
+        {
             print_colored("  ✅ ", 0x0A, 0x00);
             print(features[i]);
             print("\n");

--- a/setup/kernelconfig.h
+++ b/setup/kernelconfig.h
@@ -60,7 +60,8 @@ ESTRATEGIAS DISPONIBLES:
     #define IR0_IO_BUFFER_SIZE (64 * 1024)  // 64KB
     
     // Funciones de inicialización
-    void ir0_desktop_init(void) {
+    void ir0_desktop_init(void) 
+    {
         // Inicializar subsistemas de escritorio
         ir0_init_gui();
         ir0_init_audio();
@@ -106,7 +107,8 @@ ESTRATEGIAS DISPONIBLES:
     #define IR0_IO_BUFFER_SIZE (256 * 1024)  // 256KB
     
     // Funciones de inicialización
-    void ir0_server_init(void) {
+    void ir0_server_init(void) 
+    {
         // Inicializar subsistemas de servidor
         ir0_init_networking();
         ir0_init_ssl();
@@ -153,7 +155,8 @@ ESTRATEGIAS DISPONIBLES:
     #define IR0_IO_BUFFER_SIZE (4 * 1024)  // 4KB
     
     // Funciones de inicialización
-    void ir0_iot_init(void) {
+    void ir0_iot_init(void) 
+    {
         // Inicializar subsistemas IoT
         ir0_init_lapic_timer();
         ir0_init_low_power_mode();
@@ -200,7 +203,8 @@ ESTRATEGIAS DISPONIBLES:
     #define IR0_IO_BUFFER_SIZE (1 * 1024)  // 1KB
     
     // Funciones de inicialización
-    void ir0_embedded_init(void) {
+    void ir0_embedded_init(void) 
+    {
         // Inicializar subsistemas embebidos
         ir0_init_minimal_timer();
         ir0_init_low_power_mode();
@@ -243,7 +247,8 @@ ESTRATEGIAS DISPONIBLES:
     #define IR0_IO_BUFFER_SIZE (16 * 1024)  // 16KB
     
     // Funciones de inicialización
-    void ir0_generic_init(void) {
+    void ir0_generic_init(void) 
+    {
         // Inicialización genérica
         ir0_init_basic_subsystems();
     }
@@ -254,75 +259,93 @@ ESTRATEGIAS DISPONIBLES:
 // ===============================================================================
 
 // Funciones de inicialización de subsistemas
-void ir0_init_gui(void) {
+void ir0_init_gui(void) 
+{
     // TODO: Implementar inicialización de GUI
 }
 
-void ir0_init_audio(void) {
+void ir0_init_audio(void) 
+{
     // TODO: Implementar inicialización de audio
 }
 
-void ir0_init_usb(void) {
+void ir0_init_usb(void) 
+{
     // TODO: Implementar inicialización de USB
 }
 
-void ir0_init_networking(void) {
+void ir0_init_networking(void) 
+{
     // TODO: Implementar inicialización de networking
 }
 
-void ir0_init_multimedia(void) {
+void ir0_init_multimedia(void) 
+{
     // TODO: Implementar inicialización de multimedia
 }
 
-void ir0_init_printing(void) {
+void ir0_init_printing(void) 
+{
     // TODO: Implementar inicialización de printing
 }
 
-void ir0_init_ssl(void) {
+void ir0_init_ssl(void) 
+{
     // TODO: Implementar inicialización de SSL
 }
 
-void ir0_init_docker_runtime(void) {
+void ir0_init_docker_runtime(void) 
+{
     // TODO: Implementar inicialización de Docker runtime
 }
 
-void ir0_init_virtualization(void) {
+void ir0_init_virtualization(void) 
+{
     // TODO: Implementar inicialización de virtualización
 }
 
-void ir0_init_network_security(void) {
+void ir0_init_network_security(void) 
+{
     // TODO: Implementar inicialización de seguridad de red
 }
 
-void ir0_init_lapic_timer(void) {
+void ir0_init_lapic_timer(void) 
+{
     // TODO: Implementar inicialización de timer LAPIC
 }
 
-void ir0_init_low_power_mode(void) {
+void ir0_init_low_power_mode(void) 
+{
     // TODO: Implementar inicialización de modo de baja potencia
 }
 
-void ir0_init_network_lightweight(void) {
+void ir0_init_network_lightweight(void) 
+{
     // TODO: Implementar inicialización de networking ligero
 }
 
-void ir0_init_sensor_interface(void) {
+void ir0_init_sensor_interface(void) 
+{
     // TODO: Implementar inicialización de interfaz de sensores
 }
 
-void ir0_init_power_management(void) {
+void ir0_init_power_management(void) 
+{
     // TODO: Implementar inicialización de gestión de energía
 }
 
-void ir0_init_minimal_timer(void) {
+void ir0_init_minimal_timer(void) 
+{
     // TODO: Implementar inicialización de timer mínimo
 }
 
-void ir0_init_basic_io(void) {
+void ir0_init_basic_io(void) 
+{
     // TODO: Implementar inicialización de I/O básico
 }
 
-void ir0_init_basic_subsystems(void) {
+void ir0_init_basic_subsystems(void) 
+{
     // TODO: Implementar inicialización de subsistemas básicos
 }
 


### PR DESCRIPTION
Closes #8 

### Summary
- Reformatted the following (10 among the remaining) files to Allman (BSD) brace style:
    - ARM_PORTABILITY_GUIDE.md
    - CONFIGURATION_SYSTEM_README.md
    - INCLUDE_SYSTEM_GUIDE.md
    - kernel_config.c
    - kernelconfig.h
    - README.md
    - CONTRIBUTING.md
    - analyze_debug_logs.sh
    - build_simple.sh
    - menu_builder.sh
- Opening braces moved to a new line
- Manual edits only, no logic changes

### Notes
- Only the above files were updated; others may still need formatting
- PR targets dev branch as requested
- Files edited include major modules not formatted in the first PR 